### PR TITLE
Tweak precipitation spacing, make forecast scrollable in horizontal

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Widget text reacts to system dark/light theme on <= Android 11
 - Each hourly and coming data cell (besides description) is as wide as the widest cell in the list
 - Current hour pairs too close together
+- Inconsistent spacing between hour and coming data columns
+- Forecast not scrolling in horizontal orientation
 ### Added
 - iOS support
 - OpenWeatherMap as forecast provider

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Widget rounded corners on <= Android 11
 - Widget text reacts to system dark/light theme on <= Android 11
 - Each hourly and coming data cell (besides description) is as wide as the widest cell in the list
+- Current hour pairs too close together
 ### Added
 - iOS support
 - OpenWeatherMap as forecast provider

--- a/app/src/main/java/hr/dtakac/prognoza/ui/forecast/ComingItem.kt
+++ b/app/src/main/java/hr/dtakac/prognoza/ui/forecast/ComingItem.kt
@@ -98,7 +98,7 @@ fun ComingItem(
                     overflow = TextOverflow.Ellipsis
                 )
                 day.precipitation.asString().takeIf { it.isNotBlank() }?.let {
-                    Spacer(modifier = Modifier.width(8.dp))
+                    Spacer(modifier = Modifier.width(12.dp))
                     Text(
                         modifier = Modifier.width(dimensions.precipitationWidth),
                         text = it,
@@ -108,7 +108,7 @@ fun ComingItem(
                         color = LocalContentColor.current.copy(alpha = PrognozaTheme.alpha.medium)
                     )
                 }
-                Spacer(modifier = Modifier.width(16.dp))
+                Spacer(modifier = Modifier.width(12.dp))
                 Text(
                     modifier = Modifier.width(dimensions.lowHighTemperatureWidth),
                     text = day.lowHighTemperature.asString(),

--- a/app/src/main/java/hr/dtakac/prognoza/ui/forecast/ForecastContent.kt
+++ b/app/src/main/java/hr/dtakac/prognoza/ui/forecast/ForecastContent.kt
@@ -338,7 +338,8 @@ private fun DescriptionAndPrecipitation(
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.SpaceBetween
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
         val annotatedString = buildAnnotatedString {
             append("$description ")
@@ -363,13 +364,14 @@ private fun DescriptionAndPrecipitation(
             Text(
                 text = annotatedString,
                 inlineContent = inlineContentMap,
-                modifier = Modifier.weight(3f),
+                modifier = Modifier.weight(1f),
             )
             precipitation.takeIf { it.isNotBlank() }?.let {
                 Text(
                     text = it,
                     textAlign = TextAlign.End,
-                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    modifier = Modifier.padding(start = 16.dp).width(IntrinsicSize.Min),
                 )
             }
         }

--- a/app/src/main/java/hr/dtakac/prognoza/ui/forecast/ForecastContent.kt
+++ b/app/src/main/java/hr/dtakac/prognoza/ui/forecast/ForecastContent.kt
@@ -77,7 +77,8 @@ fun ForecastContent(
                     forecast = state.forecast,
                     isPlaceVisible = { toolbarPlaceVisible = !it },
                     isDateVisible = { toolbarDateVisible = !it },
-                    isTemperatureVisible = { toolbarTemperatureVisible = !it }
+                    isTemperatureVisible = { toolbarTemperatureVisible = !it },
+                    modifier = Modifier.fillMaxWidth()
                 )
 
                 if (state.error != null) {

--- a/app/src/main/java/hr/dtakac/prognoza/ui/forecast/ForecastContent.kt
+++ b/app/src/main/java/hr/dtakac/prognoza/ui/forecast/ForecastContent.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.Placeholder
@@ -338,8 +339,7 @@ private fun DescriptionAndPrecipitation(
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
+        horizontalArrangement = Arrangement.SpaceBetween
     ) {
         val annotatedString = buildAnnotatedString {
             append("$description ")
@@ -364,14 +364,19 @@ private fun DescriptionAndPrecipitation(
             Text(
                 text = annotatedString,
                 inlineContent = inlineContentMap,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .weight(1f)
+                    .alignBy(FirstBaseline),
             )
             precipitation.takeIf { it.isNotBlank() }?.let {
                 Text(
                     text = it,
                     textAlign = TextAlign.End,
                     maxLines = 1,
-                    modifier = Modifier.padding(start = 16.dp).width(IntrinsicSize.Min),
+                    modifier = Modifier
+                        .padding(start = 16.dp)
+                        .width(IntrinsicSize.Min)
+                        .alignBy(FirstBaseline),
                 )
             }
         }

--- a/app/src/main/java/hr/dtakac/prognoza/ui/forecast/HourItem.kt
+++ b/app/src/main/java/hr/dtakac/prognoza/ui/forecast/HourItem.kt
@@ -84,7 +84,7 @@ fun HourItem(
                 overflow = TextOverflow.Ellipsis
             )
             hour.precipitation.asString().takeIf { it.isNotBlank() }?.let {
-                Spacer(modifier = Modifier.width(8.dp))
+                Spacer(modifier = Modifier.width(12.dp))
                 Text(
                     modifier = Modifier.width(dimensions.precipitationWidth),
                     text = it,
@@ -94,7 +94,7 @@ fun HourItem(
                     color = LocalContentColor.current.copy(alpha = PrognozaTheme.alpha.medium)
                 )
             }
-            Spacer(modifier = Modifier.width(16.dp))
+            Spacer(modifier = Modifier.width(12.dp))
             Text(
                 modifier = Modifier.width(dimensions.temperatureWidth),
                 text = hour.temperature.asString(),


### PR DESCRIPTION
Changes: 
- add spacing before precipitation in description-precipitation pair
- even space around precipitation in hour item
- even space around precipitation in coming item
- make list react to swipes when horizontal