### PR TITLE
Improve appearance of preference dialog entries

### DIFF
--- a/androidApp/src/main/java/hr/dtakac/prognoza/ui/settings/PickerDialog.kt
+++ b/androidApp/src/main/java/hr/dtakac/prognoza/ui/settings/PickerDialog.kt
@@ -6,10 +6,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import hr.dtakac.prognoza.ui.common.AppDialog
@@ -55,7 +57,7 @@ private fun OptionsList(
                 onClick = { onIndexSelect(idx) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 8.dp)
+                    .padding(vertical = 8.dp, horizontal = 10.dp)
             )
         }
     }
@@ -70,6 +72,7 @@ private fun Option(
 ) {
     Row(
         modifier = Modifier
+            .clip(RoundedCornerShape(16.dp))
             .clickable(onClick = onClick)
             .then(modifier),
         verticalAlignment = Alignment.CenterVertically


### PR DESCRIPTION
Hey, thanks for bringing such an awesome app to live!

This PR adds a `RoundedCornerShape` for the radio list items in the preferences to improve the visual effect when hovering them, as it's been edged previously.

Cheers